### PR TITLE
Update 'suite.py' to fix the suite score

### DIFF
--- a/promptimize/suite.py
+++ b/promptimize/suite.py
@@ -157,7 +157,7 @@ class Suite:
         suite_score = None
         if len(tested) > 0:
             total_weight = sum([p.weight for p in tested])
-            suite_score = sum([p.execution.score for p in tested]) / total_weight
+            suite_score = sum([p.execution.score * p.weight for p in tested]) / total_weight
         d = {
             "suite_score": suite_score,
             "git_info": utils.get_git_info(),


### PR DESCRIPTION
There was a problem with the weighted score.
The scoring was ignoring the specific weight of each prompt.

Before, Suite calculates the suite_score like this:
```
sum([each prompt score]) / sum([all prompts weight])
```
The new suite_score does it like this:
```
sum([each prompt score]/[each prompt weight]) / sum([all prompts weight])
```

Example.
I have 9 pondered tests:
Test 1=> score: 1.0 - weight: 2
Test 2=> score: 1.0 - weight: 2
Test 3=> score: 1.0 - weight: 2
Test 4=> score: 1.0 - weight: 1
Test 5=> score: 1.0 - weight: 1
Test 6=> score: 1.0 - weight: 1
Test 7=> score: 1.0 - weight: 1
Test 8=> score: 1.0 - weight: 1
Test 9=> score: 0.0 - weight: 1
Before the suite score was: (1+1+1+1+1+1+1+1+0)/(2+2+2+1+1+1+1+1+1) = 8/12 = 0,666
Now, the suite score is: (1x2+1x2+1x2+1x1+1x1+1x1+1x1+1x1+0x1)/(2+2+2+1+1+1+1+1+1) = 11/12 = 0,916