### PR TITLE
Support Use of LLM's Deployed in Azure Open AI

### DIFF
--- a/promptimize/prompt_cases.py
+++ b/promptimize/prompt_cases.py
@@ -72,7 +72,7 @@ class BasePromptCase:
         if os.environ.get("OPENAI_API_TYPE") == "azure":
             if not os.environ.get("AZURE_DEPLOYMENT_NAME"):
                 raise Exception(
-                    "Environment variable with key name 'AZURE_DEPLOYMENT_NAME'"\
+                    "Environment variable with key name 'AZURE_DEPLOYMENT_NAME'"
                     "is required when OPEN_API_TYPE=='azure'."
                 )
             return AzureOpenAI(

--- a/promptimize/prompt_cases.py
+++ b/promptimize/prompt_cases.py
@@ -69,10 +69,14 @@ class BasePromptCase:
         model_name = os.environ.get("OPENAI_MODEL") or "text-davinci-003"
         openai_api_key = os.environ.get("OPENAI_API_KEY")
         self.prompt_executor_kwargs = {"model_name": model_name}
-        if os.environ.get('OPENAI_API_TYPE') == 'azure':
+        if os.environ.get("OPENAI_API_TYPE") == "azure":
             if not os.environ.get("AZURE_DEPLOYMENT_NAME"):
-                raise Exception("Environment variable with key name 'AZURE_DEPLOYMENT_NAME' is required when OPEN_API_TYPE=='azure'.")
-            return AzureOpenAI(model_name=model_name, deployment_name=os.environ.get('AZURE_DEPLOYMENT_NAME'))
+                raise Exception(
+                    "Environment variable with key name 'AZURE_DEPLOYMENT_NAME' is required when OPEN_API_TYPE=='azure'."
+                )
+            return AzureOpenAI(
+                model_name=model_name, deployment_name=os.environ.get("AZURE_DEPLOYMENT_NAME")
+            )
         return OpenAI(model_name=model_name, openai_api_key=openai_api_key)
 
     def execute_prompt(self, prompt_str):

--- a/promptimize/prompt_cases.py
+++ b/promptimize/prompt_cases.py
@@ -72,7 +72,8 @@ class BasePromptCase:
         if os.environ.get("OPENAI_API_TYPE") == "azure":
             if not os.environ.get("AZURE_DEPLOYMENT_NAME"):
                 raise Exception(
-                    "Environment variable with key name 'AZURE_DEPLOYMENT_NAME' is required when OPEN_API_TYPE=='azure'."
+                    "Environment variable with key name 'AZURE_DEPLOYMENT_NAME'"\
+                    "is required when OPEN_API_TYPE=='azure'."
                 )
             return AzureOpenAI(
                 model_name=model_name, deployment_name=os.environ.get("AZURE_DEPLOYMENT_NAME")

--- a/promptimize/prompt_cases.py
+++ b/promptimize/prompt_cases.py
@@ -70,6 +70,8 @@ class BasePromptCase:
         openai_api_key = os.environ.get("OPENAI_API_KEY")
         self.prompt_executor_kwargs = {"model_name": model_name}
         if os.environ.get('OPENAI_API_TYPE') == 'azure':
+            if not os.environ.get("AZURE_DEPLOYMENT_NAME"):
+                raise Exception("Environment variable with key name 'AZURE_DEPLOYMENT_NAME' is required when OPEN_API_TYPE=='azure'.")
             return AzureOpenAI(model_name=model_name, deployment_name=os.environ.get('AZURE_DEPLOYMENT_NAME'))
         return OpenAI(model_name=model_name, openai_api_key=openai_api_key)
 

--- a/promptimize/prompt_cases.py
+++ b/promptimize/prompt_cases.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any, Callable, List, Optional, Union
 
-from langchain.llms import OpenAI
+from langchain.llms import OpenAI, AzureOpenAI
 from langchain.callbacks import get_openai_callback
 
 from box import Box
@@ -69,6 +69,8 @@ class BasePromptCase:
         model_name = os.environ.get("OPENAI_MODEL") or "text-davinci-003"
         openai_api_key = os.environ.get("OPENAI_API_KEY")
         self.prompt_executor_kwargs = {"model_name": model_name}
+        if os.environ.get('OPENAI_API_TYPE') == 'azure':
+            return AzureOpenAI(model_name=model_name, deployment_name=os.environ.get('AZURE_DEPLOYMENT_NAME'))
         return OpenAI(model_name=model_name, openai_api_key=openai_api_key)
 
     def execute_prompt(self, prompt_str):


### PR DESCRIPTION
### Summary
While the package abstracts away the llm connections in a very useful way, being unable to uniquely configure the langchain llm instantiation means that Azure OpenAI can't be used. The reason for this is that in lanchain, Azure deployed LLM's require different arguments than standard openai llm's do.

### This Fix
This fix introduces bare minimum functionality to allow promptimize to work with Azure OpenAI. LangChain accepts the OPENAI_API_TYPE=='azure' environment variable, but when this is present it expects at least a deployment name to accompany the modelname. base url and key are passed via environment variables the same as a non-azure deployment. 
With this fix, Azure users can simply provide the api type of 'azure' accompanies by an environment variable of AZURE_DEPLOYMENT_NAME, and the promptimize tests will work for them like they do for OpenAI deployments.

### Benefits to Maintainers
Issues raised by Azure users will have a clear path to resolution after this merge. In addition, this unlocks individual and corporate adoption for Azure users, a large cohort of the LLM consumption community.